### PR TITLE
feat: allow to transcode the stream for archiving

### DIFF
--- a/earhorn/archive.py
+++ b/earhorn/archive.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from subprocess import DEVNULL, run
 from threading import Thread
+from typing import Optional
 
 from loguru import logger
 
@@ -14,6 +15,8 @@ class Archiver(Thread):
     segment_size: int
     segment_filename: str
     segment_format: str
+    segment_format_options: Optional[str]
+    copy_stream: bool
 
     # pylint: disable=too-many-arguments
     def __init__(
@@ -23,6 +26,8 @@ class Archiver(Thread):
         segment_size: int,
         segment_filename: str,
         segment_format: str,
+        segment_format_options: Optional[str],
+        copy_stream: bool,
     ):
         Thread.__init__(self)
         self.url = url
@@ -34,23 +39,31 @@ class Archiver(Thread):
         self.segment_size = segment_size
         self.segment_filename = segment_filename
         self.segment_format = segment_format
+        self.segment_format_options = segment_format_options
+        self.copy_stream = copy_stream
 
     def run(self):
         logger.info("starting archiver")
-        args = (
-            *("ffmpeg", "-hide_banner", "-nostats"),
-            *("-re", "-i", self.url),
-            "-vn",  # Drop video
-            *("-c", "copy"),
-            *("-map", "0"),
-            *("-map_metadata", "-1"),
-            *("-f", "segment"),
-            *("-strftime", "1"),
-            *("-segment_time", str(self.segment_size)),
-            *("-segment_format", self.segment_format),
-            *("-reset_timestamps", "1"),
-            self.path / f"{self.segment_filename}.{self.segment_format}",
-        )
 
-        run(args, check=True, stderr=DEVNULL)
+        cmd = ["ffmpeg", "-hide_banner", "-nostats"]
+
+        cmd += ("-re", "-i", self.url)
+        cmd += ("-vn",)  # Drop video
+        if self.copy_stream:
+            logger.info("enabling stream copy")
+            cmd += ("-c", "copy")
+
+        cmd += ("-map", "0")
+        cmd += ("-map_metadata", "-1")
+
+        cmd += ("-f", "segment")
+        cmd += ("-strftime", "1")
+        cmd += ("-segment_time", str(self.segment_size))
+        cmd += ("-segment_format", self.segment_format)
+        if self.segment_format_options:
+            cmd += ("-segment_format_options", self.segment_format_options)
+        cmd += ("-reset_timestamps", "1")
+        cmd += (self.path / f"{self.segment_filename}.{self.segment_format}",)
+
+        run(cmd, check=True, stderr=DEVNULL)
         logger.info("archiver stopped")

--- a/earhorn/main.py
+++ b/earhorn/main.py
@@ -63,6 +63,17 @@ from .silence import SilenceListener
     default="ogg",
     show_default=True,
 )
+@click.option(
+    "--archive-segment-format-options",
+    envvar="ARCHIVE_SEGMENT_FORMAT_OPTIONS",
+    help="Archive segment format options.",
+)
+@click.option(
+    "--archive-copy-stream",
+    envvar="ARCHIVE_COPY_STREAM",
+    help="Copy the stream to archive without transcoding.",
+    is_flag=True,
+)
 @click.argument(
     "url",
     envvar="URL",
@@ -76,6 +87,8 @@ def cli(
     archive_segment_size: int,
     archive_segment_filename: str,
     archive_segment_format: str,
+    archive_segment_format_options: Optional[str],
+    archive_copy_stream: bool,
 ):
     """
     URL of the stream.
@@ -120,6 +133,8 @@ def cli(
                 archive_segment_size,
                 archive_segment_filename,
                 archive_segment_format,
+                archive_segment_format_options,
+                archive_copy_stream,
             )
             archiver.start()
             threads.append(archiver)


### PR DESCRIPTION
Stream copy is not set by default anymore, enable the copy using the `--archive-copy-stream` flag.

Fixes #35