### PR TITLE
fix: recreate segments.csv fifo when restarting the listener

### DIFF
--- a/earhorn/stream.py
+++ b/earhorn/stream.py
@@ -89,6 +89,12 @@ class StreamListener:
     def listen(self):
         logger.info("starting stream listener")
 
+        # Run setup tasks before starting to listen for the stream
+        for handler in self._handlers:
+            if hasattr(handler, "before_listen_start"):
+                logger.debug(f"preparing {handler.__class__.__name__} ")
+                handler.before_listen_start()
+
         command = self._ffmpeg_command()
         logger.debug(f"running command '{' '.join(command)}'")
 

--- a/earhorn/stream_archive.py
+++ b/earhorn/stream_archive.py
@@ -81,7 +81,6 @@ class ArchiveHandler:
 
         self.tmp_dir = Path(mkdtemp(prefix="earhorn-"))
         self.tmp_segment_list = self.tmp_dir / self.TMP_SEGMENTS_LIST_FILENAME
-        _mkfifo(self.tmp_segment_list)
 
     def _tmp_segment_filename(self) -> Path:
         return Path(
@@ -151,6 +150,9 @@ class ArchiveHandler:
                 )
 
         self.tmp_segment_list.unlink()
+
+    def before_listen_start(self):
+        _mkfifo(self.tmp_segment_list)
 
     # pylint: disable=unused-argument
     def process_handler(self, threads: List[Thread], process: Popen):


### PR DESCRIPTION
Fix #116