### PR TITLE
feat: remove sentry

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ FROM base AS dev
 WORKDIR /src
 COPY . .
 RUN set -eux; \
-    pip --no-cache-dir install --editable .[s3,sentry]
+    pip --no-cache-dir install --editable .[s3]
 
 # Run
 USER ${UID}:${GID}
@@ -48,7 +48,7 @@ WORKDIR /src
 COPY --from=build /src/dist/*.whl .
 RUN set -eux; \
     export WHEEL=$(echo *.whl); \
-    pip --no-cache-dir install --no-compile "${WHEEL}[s3,sentry]"; \
+    pip --no-cache-dir install --no-compile "${WHEEL}[s3]"; \
     rm -Rf /src
 
 # Run

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ all: install format lint test
 install: venv
 venv:
 	python3 -m venv venv
-	venv/bin/pip install -e .[dev,s3,sentry]
+	venv/bin/pip install -e .[dev,s3]
 
 lint: venv
 	venv/bin/pylint --jobs=$(CPU_CORES) earhorn tests

--- a/earhorn/main.py
+++ b/earhorn/main.py
@@ -1,5 +1,4 @@
 import logging
-import os
 from queue import Queue
 from signal import SIGINT, SIGTERM, signal
 from threading import Event as ThreadEvent
@@ -9,7 +8,6 @@ import click
 from dotenv import load_dotenv
 from prometheus_client import start_http_server
 
-from . import version
 from .event import EventHandler, FileHook, PrometheusHook
 from .stats import StatsCollector
 from .stream import StreamListener, StreamListenerHandler
@@ -240,16 +238,6 @@ def cli(
         level=log_level.upper(),
         format="%(asctime)s | %(levelname)-8s | %(name)s:%(funcName)s:%(lineno)s - %(message)s",
     )
-
-    if "SENTRY_DSN" in os.environ:
-        logger.info("installing sentry")
-        # pylint: disable=import-outside-toplevel
-        import sentry_sdk
-
-        sentry_sdk.init(
-            traces_sample_rate=1.0,
-            release=version,
-        )
 
     if stream_url is None and stats_url is None:
         raise click.UsageError("Specify at least one of --stream-url or --stats-url.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,6 @@ dev = [
   "types-boto3>=1.0.2,<2.0",
 ]
 s3 = ["boto3>=1.24.8,<2.0"]
-sentry = ["sentry-sdk>=2.39,<2.40"]
 
 [project.scripts]
 earhorn = "earhorn.main:cli"


### PR DESCRIPTION
Remove sentry, a future replacement should the python OTEL instrumentation.

:warning: This is a breaking change.